### PR TITLE
Add bytestring >= 0.10 bound

### DIFF
--- a/kraken.cabal
+++ b/kraken.cabal
@@ -34,7 +34,7 @@ library
 
   build-depends:
      base >=4.5 && <4.10
-   , bytestring
+   , bytestring >= 0.10
    , http-client
    , http-client-tls
    , aeson


### PR DESCRIPTION
`kraken` seems to use `toStrict`, which is introduced in bytestring-0.10.0.0

I made the revisions on Hackage: http://hackage.haskell.org/package/kraken-0.0.3/revisions/, so no need to make a release.
